### PR TITLE
一覧系で条件を入れページングすると不正な検索が行われる

### DIFF
--- a/Tools/Create/Templates/list/Components/Pages/Page.txt
+++ b/Tools/Create/Templates/list/Components/Pages/Page.txt
@@ -32,7 +32,7 @@ else
     </div>
 
     @* 検索条件 *@
-    <EditForm method="post" Model="Model" OnSubmit="Search" id="seach">
+    <EditForm method="post" Model="InputModel" OnSubmit="Search" id="seach">
         <div class="card col-md-8 offset-md-2 mb-5">
             <div class="card-body">
 
@@ -41,18 +41,18 @@ else
                 <div class="row row-margin">
                     <div class="col">
                         <label class="" for="SerchProductName">製品名(あいまい検索)</label>
-                        <InputText class="col-md-6" id="SerchProductName" @bind-Value="Model!.ProductName" />
+                        <InputText class="col-md-6" id="SerchProductName" @bind-Value="InputModel!.ProductName" />
                     </div>
                 </div>
 
                 <div class="row row-margin">
                     <div class="col">
                         <label class="col-md-4" for="StartUnitPrice">単価</label>
-                        <InputNumber class="col-md-4 text-end" id="StartUnitPrice" @bind-Value="Model!.StartUnitPrice" />
+                        <InputNumber class="col-md-4 text-end" id="StartUnitPrice" @bind-Value="InputModel!.StartUnitPrice" />
                     </div>
                     <div class="col">
                         <label class="col-md-4" for="EndUnitPrice">〜</label>
-                        <InputNumber class="col-md-4 text-end" id="EndUnitPrice" @bind-Value="Model!.EndUnitPrice" />
+                        <InputNumber class="col-md-4 text-end" id="EndUnitPrice" @bind-Value="InputModel!.EndUnitPrice" />
                     </div>
                 </div>
 
@@ -119,6 +119,14 @@ else
     /// </summary>
     private bool DisabledEnterKey = false;
 
+    /// <summary>
+    /// 入力条件
+    /// </summary>
+    private Input$ClassName$Model InputModel { get; set; } = new();
+
+    /// <summary>
+    /// 検索条件
+    /// </summary>
     private Input$ClassName$Model Model { get; set; } = new();
 
     #region ページング用
@@ -213,7 +221,10 @@ else
                 // 検索条件の復元
                 var tempModel = await GetAsync<Input$ClassName$Model>(SessionSearch);
                 if (tempModel is not null) 
-                    Model = tempModel;
+                    InputModel = tempModel;
+
+                // 検索条件に入力条件を設定
+                Model = InputModel.Copy();
 
                 // 検索結果を取得(総レコード数更新)
                 ShowPage(Page, true);
@@ -245,6 +256,7 @@ else
             DisabledEnterKey = false;
             // 遷移情報削除
             await DeleteAsync(SessionSearch);
+            InputModel = new();
             Model = new();
             TotalRecords = repository.GetTotalRecord(Model);
             Navigation.NavigateTo("/$uri$/1");
@@ -260,7 +272,10 @@ else
         Page = 1;
 
         // 検索条件の保存
-        await SetAsync(SessionSearch, Model);
+        await SetAsync(SessionSearch, InputModel);
+
+        // 検索条件に入力条件を設定
+        Model = InputModel.Copy();
 
         // 検索結果を取得(総レコード数更新)
         ShowPage(Page, true);

--- a/Tools/Create/Templates/list/Components/Pages/Page.txt
+++ b/Tools/Create/Templates/list/Components/Pages/Page.txt
@@ -188,6 +188,8 @@ else
     }
     #endregion
 
+    /// <summary>
+    /// 初期処理
     /// </summary>
     /// <param name="firstRender">初回表示か否か</param>
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/Tools/Create/Templates/list/Components/Pages/Page.txt
+++ b/Tools/Create/Templates/list/Components/Pages/Page.txt
@@ -158,6 +158,13 @@ else
     {
         await base.OnParametersSetAsync();
 
+        // 入力条件と検索条件が不一致の場合
+        if (InputModel != Model)
+        {
+            // 入力情報を検索条件で上書き
+            InputModel = Model.Copy();
+        }
+
         // 検索結果を取得
         ShowPage(Page);
     }

--- a/Tools/Create/Templates/list/Models/InputModel.txt
+++ b/Tools/Create/Templates/list/Models/InputModel.txt
@@ -3,7 +3,7 @@ namespace WebApp.Models;
 /// <summary>
 /// Input$ClassName$Model 検索条件
 /// </summary>
-public class Input$ClassName$Model
+public record Input$ClassName$Model
 {
     // TODO 検索条件追加
     // public string? ProductName { set; get; }

--- a/Tools/Create/Templates/list/Models/InputModel.txt
+++ b/Tools/Create/Templates/list/Models/InputModel.txt
@@ -11,4 +11,13 @@ public class Input$ClassName$Model
     // public decimal? EndUnitPrice { set; get; }
     // public decimal? StartTotalPrice { set; get; }
     // public decimal? EndTotalPrice { set; get; }
+
+    /// <summary>
+    /// 複製
+    /// </summary>
+    /// <returns>複製オブジェクト</returns>
+    public Input$ClassName$Model Copy()
+    {
+        return (Input$ClassName$Model)this.MemberwiseClone();
+    }
 }

--- a/Tools/Create/Templates/template/Models/InputModel.txt
+++ b/Tools/Create/Templates/template/Models/InputModel.txt
@@ -6,4 +6,13 @@ namespace WebApp.Models;
 public class Input$ClassName$Model
 {
     // TODO 入力情報
+
+    /// <summary>
+    /// 複製
+    /// </summary>
+    /// <returns>複製オブジェクト</returns>
+    public Input$ClassName$Model Copy()
+    {
+        return (Input$ClassName$Model)this.MemberwiseClone();
+    }
 }

--- a/Tools/Create/Templates/template/Models/InputModel.txt
+++ b/Tools/Create/Templates/template/Models/InputModel.txt
@@ -3,7 +3,7 @@ namespace WebApp.Models;
 /// <summary>
 /// Input$ClassName$Model 入力情報
 /// </summary>
-public class Input$ClassName$Model
+public record Input$ClassName$Model
 {
     // TODO 入力情報
 

--- a/WebApp/Components/Pages/Order.razor
+++ b/WebApp/Components/Pages/Order.razor
@@ -120,6 +120,11 @@ else
     /// </summary>
     private bool DisabledEnterKey = false;
 
+    /// <summary>
+    /// 入力条件
+    /// </summary>
+    private InputOrderModel InputModel { get; set; } = new();
+
     private InputOrderModel Model { get; set; } = new();
 
     #region ページング用

--- a/WebApp/Components/Pages/Order.razor
+++ b/WebApp/Components/Pages/Order.razor
@@ -154,6 +154,13 @@ else
     {
         await base.OnParametersSetAsync();
 
+        // 入力条件と検索条件が不一致の場合
+        if (InputModel != Model)
+        {
+            // 入力情報を検索条件で上書き
+            InputModel = Model.Copy();
+        }
+
         // 検索結果を取得
         ShowPage(Page);
     }

--- a/WebApp/Components/Pages/Order.razor
+++ b/WebApp/Components/Pages/Order.razor
@@ -41,36 +41,36 @@ else
         </div>
     </div>
 
-    <EditForm method="post" Model="Model" OnSubmit="Search" id="seach">
+    <EditForm method="post" Model="InputModel" OnSubmit="Search" id="seach">
         <div class="card col-md-8 offset-md-2 mb-5">
             <div class="card-body">
 
                 <div class="row row-margin">
                     <div class="col">
                         <label class="" for="SerchProductName">製品名(あいまい検索)</label>
-                        <InputText class="col-md-6" id="SerchProductName" @bind-Value="Model!.ProductName" />
+                        <InputText class="col-md-6" id="SerchProductName" @bind-Value="InputModel!.ProductName" />
                     </div>
                 </div>
 
                 <div class="row row-margin">
                     <div class="col">
                         <label class="col-md-4" for="StartUnitPrice">単価</label>
-                        <InputNumber class="col-md-4 text-end" id="StartUnitPrice" @bind-Value="Model!.StartUnitPrice" />
+                        <InputNumber class="col-md-4 text-end" id="StartUnitPrice" @bind-Value="InputModel!.StartUnitPrice" />
                     </div>
                     <div class="col">
                         <label class="col-md-4" for="EndUnitPrice">〜</label>
-                        <InputNumber class="col-md-4 text-end" id="EndUnitPrice" @bind-Value="Model!.EndUnitPrice" />
+                        <InputNumber class="col-md-4 text-end" id="EndUnitPrice" @bind-Value="InputModel!.EndUnitPrice" />
                     </div>
                 </div>
 
                 <div class="row row-margin">
                     <div class="col">
                         <label class="col-md-4" for="StartTotalPrice">合計金額</label>
-                        <InputNumber class="col-md-4 text-end" id="StartTotalPrice" @bind-Value="Model!.StartTotalPrice" />
+                        <InputNumber class="col-md-4 text-end" id="StartTotalPrice" @bind-Value="InputModel!.StartTotalPrice" />
                     </div>
                     <div class="col">
                         <label class="col-md-4" for="EndTotalPrice">〜</label>
-                        <InputNumber class="col-md-4 text-end" id="EndTotalPrice" @bind-Value="Model!.EndTotalPrice" />
+                        <InputNumber class="col-md-4 text-end" id="EndTotalPrice" @bind-Value="InputModel!.EndTotalPrice" />
                     </div>
                 </div>
 
@@ -125,6 +125,9 @@ else
     /// </summary>
     private InputOrderModel InputModel { get; set; } = new();
 
+    /// <summary>
+    /// 検索条件
+    /// </summary>
     private InputOrderModel Model { get; set; } = new();
 
     #region ページング用
@@ -216,7 +219,10 @@ else
                 // 検索条件の復元
                 var tempModel = await GetAsync<InputOrderModel>(SessionOrderSearch);
                 if (tempModel is not null) 
-                    Model = tempModel;
+                    InputModel = tempModel;
+
+                // 検索条件に入力条件を設定
+                Model = InputModel.Copy();
 
                 // 検索結果を取得(総レコード数更新)
                 ShowPage(Page, true);
@@ -246,6 +252,7 @@ else
         {
             DisabledEnterKey = false;
             await DeleteAsync(SessionOrderSearch);
+            InputModel = new();
             Model = new();
             TotalRecords = repository.GetTotalRecord(Model);
             Navigation.NavigateTo("/order/1");
@@ -261,7 +268,10 @@ else
         Page = 1;
 
         // 検索条件の保存
-        await SetAsync(SessionOrderSearch, Model);
+        await SetAsync(SessionOrderSearch, InputModel);
+
+        // 検索条件に入力条件を設定
+        Model = InputModel.Copy();
 
         // 検索結果を取得(総レコード数更新)
         ShowPage(Page, true);

--- a/WebApp/Components/Pages/Weather.razor
+++ b/WebApp/Components/Pages/Weather.razor
@@ -119,6 +119,8 @@ else
     /// </summary>
     private WeatherForecastModel[]? pageForecasts;
 
+    /// <summary>
+    /// 初期処理
     /// </summary>
     /// <param name="firstRender">初回表示か否か</param>
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/WebApp/Components/Pages/Weather.razor
+++ b/WebApp/Components/Pages/Weather.razor
@@ -88,6 +88,11 @@ else
     /// </summary>
     public const string SessionWeatherSearch = "SessionWeatherSearch"; 
 
+    /// <summary>
+    /// 入力条件
+    /// </summary>
+    private InputWeatherForecastModel InputModel { get; set; } = new();
+
     private InputWeatherForecastModel Model { get; set; } = new();
 
     /// <summary>

--- a/WebApp/Components/Pages/Weather.razor
+++ b/WebApp/Components/Pages/Weather.razor
@@ -201,6 +201,13 @@ else
     {
         await base.OnParametersSetAsync();
 
+        // 入力条件と検索条件が不一致の場合
+        if (InputModel != Model)
+        {
+            // 入力情報を検索条件で上書き
+            InputModel = Model.Copy();
+        }
+
         // 検索結果を取得
         ShowPage(Page);
     }

--- a/WebApp/Components/Pages/Weather.razor
+++ b/WebApp/Components/Pages/Weather.razor
@@ -27,29 +27,29 @@
 }
 else
 {
-    <EditForm method="post" Model="Model" OnSubmit="Search" id="seach">
+    <EditForm method="post" Model="InputModel" OnSubmit="Search" id="seach">
         <div class="card col-md-8 offset-md-2 mb-5">
             <div class="card-body">
 
                 <div class="row row-margin">
                     <div class="col">
                         <label class="col-md-4" for="StartDate">日付</label>
-                        <InputDate class="col-md-6" id="StartDate" @bind-Value="Model!.StartDate" />
+                        <InputDate class="col-md-6" id="StartDate" @bind-Value="InputModel!.StartDate" />
                     </div>
                     <div class="col">
                         <label class="col-md-4" for="EndDate">〜</label>
-                        <InputDate class="col-md-6" id="EndDate" @bind-Value="Model!.EndDate" />
+                        <InputDate class="col-md-6" id="EndDate" @bind-Value="InputModel!.EndDate" />
                     </div>
                 </div>
 
                 <div class="row row-margin">
                     <div class="col">
                         <label class="col-md-4" for="StartDate">温度</label>
-                        <InputNumber class="col-md-4 text-end" id="StartDate" @bind-Value="Model!.StartTemperatureC" />
+                        <InputNumber class="col-md-4 text-end" id="StartDate" @bind-Value="InputModel!.StartTemperatureC" />
                     </div>
                     <div class="col">
                         <label class="col-md-4" for="EndDate">〜</label>
-                        <InputNumber class="col-md-4 text-end" id="EndDate" @bind-Value="Model!.EndTemperatureC" />
+                        <InputNumber class="col-md-4 text-end" id="EndDate" @bind-Value="InputModel!.EndTemperatureC" />
                     </div>
                 </div>
 
@@ -93,6 +93,9 @@ else
     /// </summary>
     private InputWeatherForecastModel InputModel { get; set; } = new();
 
+    /// <summary>
+    /// 検索条件
+    /// </summary>
     private InputWeatherForecastModel Model { get; set; } = new();
 
     /// <summary>
@@ -148,8 +151,11 @@ else
 
                 // 検索条件の復元
                 var tempModel = await GetAsync<InputWeatherForecastModel>(SessionWeatherSearch);
-                if (tempModel is not null) 
-                    Model = tempModel;
+                if (tempModel is not null)
+                    InputModel = tempModel;
+
+                // 検索条件に入力条件を設定
+                Model = InputModel.Copy();
 
                 // 検索結果を取得(総レコード数更新)
                 ShowPage(Page, true);
@@ -179,6 +185,7 @@ else
         {
             DisabledEnterKey = false;
             await DeleteAsync(SessionWeatherSearch);
+            InputModel = new();
             Model = new();
             TotalRecords = repository.GetTotalRecord(Model);
             Navigation.NavigateTo("/weather/1");
@@ -205,7 +212,10 @@ else
         Page = 1;
 
         // 検索条件の保存
-        await SetAsync(SessionWeatherSearch, Model);
+        await SetAsync(SessionWeatherSearch, InputModel);
+
+        // 検索条件に入力条件を設定
+        Model = InputModel.Copy();
 
         // 検索結果を取得(総レコード数更新)
         ShowPage(Page, true);

--- a/WebApp/Models/InputOrderModel.cs
+++ b/WebApp/Models/InputOrderModel.cs
@@ -1,6 +1,6 @@
 namespace WebApp.Models;
 
-public class InputOrderModel
+public record InputOrderModel
 {
     public string? ProductName { set; get; }
     public decimal? StartUnitPrice { set; get; }

--- a/WebApp/Models/InputOrderModel.cs
+++ b/WebApp/Models/InputOrderModel.cs
@@ -7,4 +7,13 @@ public class InputOrderModel
     public decimal? EndUnitPrice { set; get; }
     public decimal? StartTotalPrice { set; get; }
     public decimal? EndTotalPrice { set; get; }
+
+    /// <summary>
+    /// 複製
+    /// </summary>
+    /// <returns>複製オブジェクト</returns>
+    public InputOrderModel Copy()
+    {
+        return (InputOrderModel)this.MemberwiseClone();
+    }
 }

--- a/WebApp/Models/InputWeatherForecastModel.cs
+++ b/WebApp/Models/InputWeatherForecastModel.cs
@@ -6,4 +6,13 @@ public class InputWeatherForecastModel
     public DateOnly? EndDate { set; get; }
     public int? StartTemperatureC { set; get; }
     public int? EndTemperatureC { set; get; }
+
+    /// <summary>
+    /// 複製
+    /// </summary>
+    /// <returns>複製オブジェクト</returns>
+    public InputWeatherForecastModel Copy()
+    {
+        return (InputWeatherForecastModel)this.MemberwiseClone();
+    }
 }

--- a/WebApp/Models/InputWeatherForecastModel.cs
+++ b/WebApp/Models/InputWeatherForecastModel.cs
@@ -1,6 +1,6 @@
 namespace WebApp.Models;
 
-public class InputWeatherForecastModel
+public record InputWeatherForecastModel
 {
     public DateOnly? StartDate { set; get; }
     public DateOnly? EndDate { set; get; }


### PR DESCRIPTION
下記条件で検索を行った状態になる。
例）/weather

1. 条件を入力(条件「温度」上限に10)
1. 2ページに遷移
1. 2ページがゼロ件表示
---
対策として下記の修正を行う
* 入力条件と検索条件を分ける(検索時、検索条件に入力条件を代入する)
* ページング時に「入力条件と検索条件が不一致」の場合は入力条件に検索条件を代入する